### PR TITLE
Adds a new hover effects in arrow and see more link

### DIFF
--- a/public/assets/javascripts/shared/directives/goTo.js
+++ b/public/assets/javascripts/shared/directives/goTo.js
@@ -6,6 +6,7 @@
       restrict: 'A',
       link: function ($scope, element, attr) {
         element.on('click', function() {
+          this.classList.add('clicked');
           angular.element('html, body').animate({
             scrollTop: angular.element(attr.container).offset().top
           }, 400);

--- a/public/assets/sass/modules/character.sass
+++ b/public/assets/sass/modules/character.sass
@@ -67,3 +67,12 @@ $module-name: 'character'
 
 .#{$module-name}-info-icon
   margin-right: 10px
+
+.#{$module-name}-link a:hover
+  text-decoration: underline
+
+.#{$module-name}-link i
+  +transition(all .1s ease-out)
+
+.#{$module-name}-link a:hover i
+  +transform(rotate(90deg))

--- a/public/assets/sass/modules/down-arrow.sass
+++ b/public/assets/sass/modules/down-arrow.sass
@@ -13,15 +13,23 @@ $module-name: 'down-arrow'
   z-index: $z-index-down-arrow
   a
     cursor: pointer
+    display: block
+    +animation(arrowDown 1.25s 2s ease infinite alternate running)
+  a.clicked
+    +animation(none)
+  a:hover .#{$module-name}-piece
+    color: $secondary-color
 
 .#{$module-name}-wrap
   width: 170px
   height: 150px
   margin: 0 auto
   position: relative
+  +transition(transform .3s ease)
 
 .#{$module-name}-piece
   position: absolute
+  +transition(color .3s ease)
 
 .#{$module-name}-left
   +transform(rotate(-47deg))
@@ -29,3 +37,11 @@ $module-name: 'down-arrow'
 .#{$module-name}-right
   left: 70px
   +transform(rotate(33deg))
+
++keyframes(arrowDown)
+  from
+    +transform(translateY(0px))
+    opacity: 1
+  to
+    +transform(translateY(20px))
+    opacity: .7

--- a/views/index.erb
+++ b/views/index.erb
@@ -89,8 +89,8 @@
             <li ng-cloak ng-show="!!character.death" class="character-info-item">
               <i class="icons-cross character-info-icon"></i> {{ character.death }}
             </li>
-            <li ng-cloak ng-show="!!character.url" class="character-info-item">
-              <i class="icons-sword character-info-icon"></i><a target="_blank" href="{{ character.url }}"> See More</a>
+            <li ng-cloak ng-show="!!character.url" class="character-info-item character-link">
+              <a target="_blank" href="{{ character.url }}"><i class="icons-sword character-info-icon"></i> See More</a>
             </li>
         </div>
         <div class="text-center clearfix">


### PR DESCRIPTION
@weslleyaraujo congrats for the project!

This PR adds:
- an animation in _arrow_ on first container, indicating that it is clickable.
- a new hover effects in _arrow_ on first container and in _see more_ link on second container. 

![arrow](https://cloud.githubusercontent.com/assets/1345662/7223095/178a1368-e6f2-11e4-82b5-dc96ebe2a577.gif)

![espada](https://cloud.githubusercontent.com/assets/1345662/7223096/178af274-e6f2-11e4-921b-64cd97b5ff05.gif)
