### PR TITLE
Feature/responsive

### DIFF
--- a/public/assets/sass/layout.sass
+++ b/public/assets/sass/layout.sass
@@ -3,7 +3,8 @@
 // ***
 
 .wrap
-  width: 1000px
+  width: 100%
+  max-width: 1000px
   margin: 0 auto
 
 .container

--- a/public/assets/sass/media-query.sass
+++ b/public/assets/sass/media-query.sass
@@ -1,54 +1,59 @@
 // ******************
 // Media query 
 // ***
-@media only screen and (max-device-width: 500px)
+@media only screen and (max-width: 1000px)
   .wrap
-    width: 100%
+    width: 95%
+  .footer .wrap
+    position: relative
+    z-index: 10
 
+@media only screen and (max-width: 720px)
+  .header h1
+    font-size: 60px
   .introduction-content
     width: 100%
-    clear: both
+    float: none
     text-align: center
-    font-size: 32px
-
-  .blood-decoration,
-  .blood-decoration-item,
-  .down-arrow,
-  .character-image-holder
+  .full-container,
+  .full-container.is-table
+    display: block
+    width: auto
+  .blood-decoration
     display: none
-
   .character
     display: block
-    float: left
-    width: 100%
-
-  .character-info
-    width: 100%
-    padding: 0
-    float: none
-    height: auto
-
-  .character-info-list
-    text-align: center
-    width: 280px
-    margin: 0 auto
-  
-  .footer p
-    text-align: center
-    float: none
-  
+    width: 95%
+    margin-left: auto
+    margin-right: auto
   .character-title
-    font-size: 100px
-
-  .full-container
-    overflow: hidden
-    display: block !important
-
-  .btn
-    padding: 10px 20px
-
-  .social
+    padding-top: 50px
+    font-size: 80px
+    text-shadow: 1px 1px 1px rgba(0, 0, 0, .5)
+  .character-image-holder
     width: 100%
+    position: relative
+    left: -40px
+  .character-info
+    height: auto
+    width: 100%
+    margin: 0 0 20px 0
+  .character-info-list
+    text-align: left
+  .footer .wrap > p,
+  .footer .wrap > ul
+    float: none
+  .footer .wrap > p
     text-align: center
-    float: left
-    margin: 0 0 30px 0
+  .footer .wrap > ul
+    width: 110px
+    margin: 0 auto
+
+@media only screen and (max-width: 880px)
+  .character .btn
+    position: relative
+
+@media only screen and (max-height: 830px)
+  // Hide the arrow for small resolutions (height)
+  .down-arrow
+    display: none

--- a/public/assets/sass/media-query.sass
+++ b/public/assets/sass/media-query.sass
@@ -8,6 +8,10 @@
     position: relative
     z-index: 10
 
+@media only screen and (max-width: 880px)
+  .character .btn
+    position: relative
+
 @media only screen and (max-width: 720px)
   .header h1
     font-size: 60px
@@ -15,6 +19,8 @@
     width: 100%
     float: none
     text-align: center
+  .full-container
+    min-height: auto
   .full-container,
   .full-container.is-table
     display: block
@@ -27,13 +33,13 @@
     margin-left: auto
     margin-right: auto
   .character-title
-    padding-top: 50px
+    padding-top: 30px
     font-size: 80px
     text-shadow: 1px 1px 1px rgba(0, 0, 0, .5)
   .character-image-holder
-    width: 100%
     position: relative
-    left: -40px
+    left: 50%
+    margin-left: -270px
   .character-info
     height: auto
     width: 100%
@@ -49,9 +55,31 @@
     width: 110px
     margin: 0 auto
 
-@media only screen and (max-width: 880px)
+@media only screen and (max-width: 530px)
+  .character-title
+    font-size: 50px
+  .character-image-holder
+    left: 0
+    height: auto
+    padding-top: 15px
+    padding-bottom: 15px
+    margin-left: 0
+  .character-image-holder > a
+    display: block
+  .character-image
+    position: static
+    left: auto
+    top: auto
+    border: solid 10px $primary-color
+    margin: 0 auto
+  .blood-photo-holder
+    background-image: none
   .character .btn
-    position: relative
+    width: 100%
+    font-size: 25px
+    padding-left: 0
+    padding-right: 0
+    +box-sizing(border-box)
 
 @media only screen and (max-height: 830px)
   // Hide the arrow for small resolutions (height)

--- a/public/assets/sass/modules/character.sass
+++ b/public/assets/sass/modules/character.sass
@@ -27,7 +27,7 @@ $module-name: 'character'
     +border-radius(50%)
 
 .#{$module-name}-info
-  width: 640px
+  width: 60%
   margin: 50px 0 0 0
   height: 300px
   &.is-full-size

--- a/views/index.erb
+++ b/views/index.erb
@@ -2,7 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Dead of Thrones - Characters killed by our sweet George RR Martin</title>
+  <!-- <title>Dead of Thrones - Characters killed by our sweet George RR Martin</title> -->
+  <title></title>
   <link rel="icon" type="image/x-icon" href="/favicon.ico">
 
   <meta name="description" content="Characters killed by our sweet George RR Martin" />


### PR DESCRIPTION
This PR adds a first version for responsive design.
For the first container I tried to maintain the visual consistency and only make the breakpoint when the text overrides the image.

![captura de tela 2015-04-21 as 17 49 32](https://cloud.githubusercontent.com/assets/1345662/7262453/0d4ab358-e850-11e4-9e0a-84733f6ea1eb.png)

For the second container I got a solution with 2 changes of layout:
- In the first I centering the content but I still keep the _blood_ visual concept;
- And in the second, for the small resolutions, I simplified the layout keeping the main colors.

![captura de tela 2015-04-21 as 17 49 49](https://cloud.githubusercontent.com/assets/1345662/7262459/161bfafa-e850-11e4-9428-7ef5ec091580.png)
![captura de tela 2015-04-21 as 17 50 00](https://cloud.githubusercontent.com/assets/1345662/7262460/16207846-e850-11e4-8419-ef503064d8c3.png)

Another change that I made is for small height resolutions I hid the arrow for it not override content.
