### PR TITLE
Fix: #14 - arrow is now displaying fine

### DIFF
--- a/public/assets/sass/media-query.sass
+++ b/public/assets/sass/media-query.sass
@@ -82,7 +82,7 @@
     padding-right: 0
     +box-sizing(border-box)
 
-@media only screen and (max-height: 830px)
+@media only screen and (max-height: 675px)
   // Hide the arrow for small resolutions (height)
   .down-arrow
     display: none


### PR DESCRIPTION
This PR will fix the media query size to display the arrow in some resolutions.

Example:
![screen shot 2015-04-26 at 8 53 43 pm](https://cloud.githubusercontent.com/assets/2286385/7339929/6c3c2374-ec56-11e4-8fed-948e058b1ad8.png)

Related to issue #14 

@raphaelfabeni what you think about that? 😃
